### PR TITLE
Encode class in aws-path

### DIFF
--- a/KwfAwsCdn/Events.php
+++ b/KwfAwsCdn/Events.php
@@ -70,7 +70,7 @@ class KwfAwsCdn_Events extends Kwf_Events_Subscriber
 
         if ($awscdnDistributionId) {
             $invalidator = new KwfAwsCdn_Invalidator(array('distributionId' => $awscdnDistributionId));
-            $path = '/media/'.$ev->class.'/'.$ev->component->componentId.'/*';
+            $path = '/media/'.rawurlencode($ev->class).'/'.$ev->component->componentId.'/*';
             $invalidator->invalidatePath($path);
         }
     }


### PR DESCRIPTION
Component-Class can contain > when using childSettings
See https://github.com/koala-framework/koala-framework/blob/5.2/Kwf/Media.php#L32